### PR TITLE
replaced temp file with buffer file

### DIFF
--- a/css-autoprefixer-test.el
+++ b/css-autoprefixer-test.el
@@ -33,8 +33,9 @@
     ()
   "When the autoprefixer fail, nothing should change"
   (with-temp-buffer
-    (insert "this is wrong css syntax so it wil fail")
+    (insert "this is wrong css syntax so it will fail")
+    (print (buffer-string))
     (css-autoprefixer)
-    (should (equal (buffer-string) "this is wrong css syntax so it wil fail"))))
+    (should (equal (buffer-string) "this is wrong css syntax so it will fail"))))
 
 ;;; css-autoprefixer-test.el ends here

--- a/css-autoprefixer.el
+++ b/css-autoprefixer.el
@@ -46,17 +46,18 @@
 
 (defun css-autoprefixer--execute-npx (filename)
   "Run autoprefix shell command for the given FILENAME. Return a list (EXITCODE, OUTPUT)"
-  (with-temp-buffer
-    (list (call-process "npx"
-                        nil
-                        (list (current-buffer) t)
-                        0
-                        "postcss"
-                        (shell-quote-argument (expand-file-name filename))
-                        "--use"
-                        "autoprefixer"
-                        "--no-map")
-          (buffer-string))))
+  (if filename
+      (with-temp-buffer
+        (list (call-process "npx"
+                            nil
+                            (list (current-buffer) t)
+                            0
+                            "postcss"
+                            (shell-quote-argument (expand-file-name filename))
+                            "--use"
+                            "autoprefixer"
+                            "--no-map")
+              (buffer-string)))))
 
 (provide 'css-autoprefixer)
 ;;; css-autoprefixer.el ends here

--- a/css-autoprefixer.el
+++ b/css-autoprefixer.el
@@ -4,6 +4,7 @@
 ;;
 ;; Author: Kyung Mo Kweon<kkweon@gmail.com> and contributors
 ;; URL: https://github.com/kkweon/emacs-css-autoprefixer
+;; Package-Version: 20180310.839
 ;; Package-Requires: ((emacs "24"))
 ;; Version: 1.0
 ;; Keywords: convenience, usability, css
@@ -26,22 +27,14 @@
 (defun css-autoprefixer ()
   "Run autoprefix in the current buffer. If error, display error messages"
   (interactive)
-  (save-excursion
-    (let* ((temp-name (make-temp-file "css-prefixer" nil ".css"))
-           (temp-css (if (region-active-p)
-                         (buffer-substring-no-properties (region-beginning)
-                                                         (region-end))
-                       (buffer-string))))
-      (with-temp-file temp-name
-        (insert temp-css))
-      (let* ((result (css-autoprefixer--execute-npx temp-name))
-             (success-p (= (car result) 0))
-             (content (car (cdr result))))
-        (if success-p
-            (progn
-              (css-autoprefixer-clean-buffer)
-              (insert content))
-          (display-message-or-buffer content))))))
+  (let* ((result (css-autoprefixer--execute-npx buffer-file-name))
+         (success-p (= (car result) 0))
+         (content (car (cdr result))))
+    (if success-p
+        (progn
+          (css-autoprefixer-clean-buffer)
+          (insert content))
+      (display-message-or-buffer content))))
 
 
 (defun css-autoprefixer-clean-buffer ()
@@ -56,8 +49,7 @@
   (with-temp-buffer
     (list (call-process "npx"
                         nil
-                        (list (current-buffer)
-                              t)
+                        (list (current-buffer) t)
                         0
                         "postcss"
                         (shell-quote-argument (expand-file-name filename))

--- a/css-autoprefixer.el
+++ b/css-autoprefixer.el
@@ -27,14 +27,14 @@
 (defun css-autoprefixer ()
   "Run autoprefix in the current buffer. If error, display error messages"
   (interactive)
-  (let* ((result (css-autoprefixer--execute-npx buffer-file-name))
-         (success-p (= (car result) 0))
-         (content (car (cdr result))))
-    (if success-p
-        (progn
-          (css-autoprefixer-clean-buffer)
-          (insert content))
-      (display-message-or-buffer content))))
+  (if buffer-file-name (let* ((result (css-autoprefixer--execute-npx buffer-file-name))
+                              (success-p (= (car result) 0))
+                              (content (car (cdr result))))
+                         (if success-p
+                             (progn
+                               (css-autoprefixer-clean-buffer)
+                               (insert content))
+                           (display-message-or-buffer content)))))
 
 
 (defun css-autoprefixer-clean-buffer ()
@@ -46,18 +46,18 @@
 
 (defun css-autoprefixer--execute-npx (filename)
   "Run autoprefix shell command for the given FILENAME. Return a list (EXITCODE, OUTPUT)"
-  (if filename
-      (with-temp-buffer
-        (list (call-process "npx"
-                            nil
-                            (list (current-buffer) t)
-                            0
-                            "postcss"
-                            (shell-quote-argument (expand-file-name filename))
-                            "--use"
-                            "autoprefixer"
-                            "--no-map")
-              (buffer-string)))))
+  (with-temp-buffer
+    (list (call-process "npx"
+                        nil
+                        (list (current-buffer)
+                              t)
+                        0
+                        "postcss"
+                        (shell-quote-argument (expand-file-name filename))
+                        "--use"
+                        "autoprefixer"
+                        "--no-map")
+          (buffer-string))))
 
 (provide 'css-autoprefixer)
 ;;; css-autoprefixer.el ends here


### PR DESCRIPTION
Hi, Thanks for looking into #2 yesterday. I can see that it was fixed and using default browsers no need to add prefixes anymore so all appeared to be working. However I have a .browserlistrc (set to Last 2 versions) in my home directory that wasn't being picked up when using autoprefixer in emacs but was using the CLI. I had a look at the code and noticed temp-file is created in private/var which autoprefixer uses to process file. This is why .browserlistrc isn't picked up so I removed the temp file and just used buffer-file instead. For me this works